### PR TITLE
Add EN/DE localization support for SoundPad UI

### DIFF
--- a/lang/de.json
+++ b/lang/de.json
@@ -1,0 +1,26 @@
+{
+  "CHRIS_SOUND_MODULE": {
+    "Setting": {
+      "EnableLoggingName": "Konsolen-Logs aktivieren",
+      "EnableLoggingHint": "Aktiviert oder deaktiviert Konsolen-Logs für das SoundPad.",
+      "OpenSoundPad": "SoundPad öffnen",
+      "SoundPadLabel": "SoundPad"
+    },
+    "UI": {
+      "SelectTargetPlayer": "Zielspieler auswählen:",
+      "DropAreaHint": "Ziehen Sie Sounds aus einer Wiedergabeliste hierher.",
+      "CurrentSound": "Aktueller Sound:",
+      "Volume": "Lautstärke:",
+      "ClearSounds": "Alle Sounds entfernen"
+    },
+    "Messages": {
+      "SelectSoundFirst": "Bitte zuerst einen Sound auswählen.",
+      "SelectPlayerFirst": "Bitte einen Spieler auswählen.",
+      "InvalidDropType": "Ungültiger Typ für Drag-and-Drop-Daten:",
+      "DropDataError": "Fehler beim Verarbeiten der Drag-and-Drop-Daten:",
+      "PlaylistNotFound": "Playlist nicht gefunden:",
+      "SoundNotFoundInPlaylist": "Sound nicht gefunden in Playlist:",
+      "GmOnly": "SoundPad ist nur für GMs verfügbar."
+    }
+  }
+}

--- a/lang/en.json
+++ b/lang/en.json
@@ -1,0 +1,26 @@
+{
+  "CHRIS_SOUND_MODULE": {
+    "Setting": {
+      "EnableLoggingName": "Enable console logs",
+      "EnableLoggingHint": "Enables or disables console logs for the SoundPad.",
+      "OpenSoundPad": "Open SoundPad",
+      "SoundPadLabel": "SoundPad"
+    },
+    "UI": {
+      "SelectTargetPlayer": "Select target player:",
+      "DropAreaHint": "Drag sounds from a playlist here.",
+      "CurrentSound": "Current sound:",
+      "Volume": "Volume:",
+      "ClearSounds": "Remove all sounds"
+    },
+    "Messages": {
+      "SelectSoundFirst": "Please select a sound first.",
+      "SelectPlayerFirst": "Please select a player.",
+      "InvalidDropType": "Invalid type for drag-and-drop data:",
+      "DropDataError": "Error while processing drag-and-drop data:",
+      "PlaylistNotFound": "Playlist not found:",
+      "SoundNotFoundInPlaylist": "Sound not found in playlist:",
+      "GmOnly": "SoundPad is only available for GMs."
+    }
+  }
+}

--- a/module.json
+++ b/module.json
@@ -11,8 +11,20 @@
     "scripts/socket-handler.js",
 	"scripts/SoundPad.js"
   ],
-    "styles": [
+  "styles": [
     "css/soundpad.css"
+  ],
+  "languages": [
+    {
+      "lang": "de",
+      "name": "Deutsch",
+      "path": "lang/de.json"
+    },
+    {
+      "lang": "en",
+      "name": "English",
+      "path": "lang/en.json"
+    }
   ],
   "authors": [
     {

--- a/scripts/SoundPad.js
+++ b/scripts/SoundPad.js
@@ -4,8 +4,8 @@ export let enableLogging = false; // Standardmäßig deaktiviert
 // Funktion zur Aktualisierung der Logging-Einstellungen
 Hooks.once("init", () => {
   game.settings.register("chris-sound-module", "enableLogging", {
-    name: "Konsolen-Logs aktivieren",
-    hint: "Aktiviert oder deaktiviert Konsolen-Logs für das SoundPad.",
+    name: game.i18n.localize("CHRIS_SOUND_MODULE.Setting.EnableLoggingName"),
+    hint: game.i18n.localize("CHRIS_SOUND_MODULE.Setting.EnableLoggingHint"),
     scope: "client", // Nur für den aktuellen Client
     config: true,
     default: false, // Standardmäßig deaktiviert
@@ -72,14 +72,14 @@ class SoundPad extends FormApplication {
       $(button).addClass("active");
 
       // Aktualisiere die Anzeige für den aktuell ausgewählten Sound
-      html.find(".selected-sound-display").text(`Aktueller Sound: ${this.selectedSoundName}`);
+      html.find(".selected-sound-display").text(this.selectedSoundName);
     });
 
     // Play-Button
     html.find(".play-button").click(() => {
       // Klick auf den Play-Button spielt den aktuell ausgewählten Sound für den ausgewählten Spieler ab.
       if (!this.selectedSoundId || !this.sounds[this.selectedSoundId]) {
-        console.error("Bitte zuerst einen Sound auswählen.");
+        console.error(game.i18n.localize("CHRIS_SOUND_MODULE.Messages.SelectSoundFirst"));
         return;
       }
 
@@ -88,7 +88,7 @@ class SoundPad extends FormApplication {
 
       const playerName = playerSelect.val();
       if (!playerName) {
-        console.warn("Bitte einen Spieler auswählen.");
+        console.warn(game.i18n.localize("CHRIS_SOUND_MODULE.Messages.SelectPlayerFirst"));
         return;
       }
 
@@ -101,7 +101,7 @@ class SoundPad extends FormApplication {
       const playerName = playerSelect.val();
 
       if (!playerName) {
-        console.warn("Bitte einen Spieler auswählen.");
+        console.warn(game.i18n.localize("CHRIS_SOUND_MODULE.Messages.SelectPlayerFirst"));
         return;
       }
 
@@ -116,7 +116,7 @@ class SoundPad extends FormApplication {
       const playerName = playerSelect.val();
 
       if (!playerName) {
-        console.warn("Bitte einen Spieler auswählen.");
+        console.warn(game.i18n.localize("CHRIS_SOUND_MODULE.Messages.SelectPlayerFirst"));
         return;
       }
 
@@ -162,7 +162,7 @@ class SoundPad extends FormApplication {
       data = JSON.parse(event.dataTransfer.getData("text/plain"));
       logMessage("Daten aus Drag-and-Drop-Event:", data); // Debugging-Ausgabe
     } catch (err) {
-      console.error("Fehler beim Verarbeiten der Drag-and-Drop-Daten:", err);
+      console.error(game.i18n.localize("CHRIS_SOUND_MODULE.Messages.DropDataError"), err);
       return;
     }
 
@@ -173,13 +173,13 @@ class SoundPad extends FormApplication {
 
       const playlist = game.playlists.get(playlistId);
       if (!playlist) {
-        console.error("Playlist nicht gefunden:", playlistId);
+        console.error(game.i18n.localize("CHRIS_SOUND_MODULE.Messages.PlaylistNotFound"), playlistId);
         return;
       }
 
       const sound = playlist.sounds.get(soundId);
       if (!sound) {
-        console.error("Sound nicht gefunden in Playlist:", soundId);
+        console.error(game.i18n.localize("CHRIS_SOUND_MODULE.Messages.SoundNotFoundInPlaylist"), soundId);
         return;
       }
 
@@ -197,20 +197,20 @@ class SoundPad extends FormApplication {
       logMessage(`Sound "${sound.name}" hinzugefügt:`, sound);
       this.render(true);
     } else {
-      console.warn("Ungültiger Typ für Drag-and-Drop-Daten:", data.type);
+      console.warn(game.i18n.localize("CHRIS_SOUND_MODULE.Messages.InvalidDropType"), data.type);
     }
   }
 }
 
 Hooks.once("ready", () => {
   if (!game.user.isGM) {
-    console.warn("SoundPad ist nur für GMs verfügbar.");
+    console.warn(game.i18n.localize("CHRIS_SOUND_MODULE.Messages.GmOnly"));
     return;
   }
 
   game.settings.registerMenu("chris-sound-module", "soundpad", {
-    name: "SoundPad öffnen",
-    label: "SoundPad",
+    name: game.i18n.localize("CHRIS_SOUND_MODULE.Setting.OpenSoundPad"),
+    label: game.i18n.localize("CHRIS_SOUND_MODULE.Setting.SoundPadLabel"),
     icon: "fas fa-music",
     type: SoundPad,
     restricted: true, // Nur GMs können das SoundPad öffnen

--- a/templates/soundpad.html
+++ b/templates/soundpad.html
@@ -1,7 +1,7 @@
 <form class="chris-sound-soundpad">
   <!-- Spieler-Auswahl -->
   <div class="form-group">
-    <label for="player-select">Zielspieler auswählen:</label>
+    <label for="player-select">{{localize "CHRIS_SOUND_MODULE.UI.SelectTargetPlayer"}}</label>
     <select id="player-select" class="player-select form-control">
       {{#each users}}
       <option value="{{this.name}}">{{this.name}}</option>
@@ -11,7 +11,7 @@
 
   <!-- Drop-Bereich für Sounds -->
   <div class="soundpad-drop-area">
-    Ziehen Sie Sounds aus einer Wiedergabeliste hierher.
+    {{localize "CHRIS_SOUND_MODULE.UI.DropAreaHint"}}
   </div>
 
   <!-- Liste der Sounds -->
@@ -25,7 +25,8 @@
 
   <!-- Anzeige des aktuell ausgewählten Sounds -->
   <div class="selected-sound-info">
-    <span class="selected-sound-display">Aktueller Sound: {{selectedSoundName}}</span>
+    <span>{{localize "CHRIS_SOUND_MODULE.UI.CurrentSound"}}</span>
+    <span class="selected-sound-display">{{selectedSoundName}}</span>
   </div>
 
   <!-- Medien-Steuerung -->
@@ -36,10 +37,10 @@
 
   <!-- Lautstärkeregler -->
   <div class="volume-control">
-    <label for="volume-slider">Lautstärke:</label>
+    <label for="volume-slider">{{localize "CHRIS_SOUND_MODULE.UI.Volume"}}</label>
     <input id="volume-slider" type="range" min="0" max="1" step="0.01" value="0.8" />
   </div>
 
   <!-- Button: Alle Sounds entfernen -->
-  <button type="button" class="clear-sounds">Alle Sounds entfernen</button>
+  <button type="button" class="clear-sounds">{{localize "CHRIS_SOUND_MODULE.UI.ClearSounds"}}</button>
 </form>


### PR DESCRIPTION
### Motivation
- Provide localized UI and user-facing messages for the SoundPad so users can switch between German and English.
- Register language files in the module manifest so Foundry can load translations per user language.

### Description
- Added a `languages` block to `module.json` and created `lang/de.json` and `lang/en.json` containing keys for settings, UI labels and runtime messages.
- Replaced hardcoded UI strings in `templates/soundpad.html` with `{{localize "..."}}` calls and separated the "Current sound" label from the displayed sound name.
- Replaced hardcoded messages and settings labels in `scripts/SoundPad.js` with `game.i18n.localize("...")` calls and preserved existing guards and control flow.
- Work performed on branch `localisation-added` and committed as the working branch for this change.